### PR TITLE
Added RD6006P support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # riden-flashtool
-Riden RD6006/RD6012/RD6018 Firmware Flash Tool
+Riden RD6006(P)/RD6012/RD6018 Firmware Flash Tool
 
 This script allows updating firmware on Riden RD60xx power supply units.
 
@@ -23,6 +23,7 @@ Currently script has been validated with following models:
 Make|Model|Info
 ----|-----|----
 RIDEN|RD6006|Tested with Bootloader V1.09
+RIDEN|RD6006P|Tested with Bootloader V1.12
 RIDEN|RD6012|Tested with Bootloader V1.09
 RIDEN|RD6018|Tested with Bootloader V1.10
 

--- a/flash-rd.py
+++ b/flash-rd.py
@@ -23,7 +23,7 @@ import argparse
 import serial
 from time import sleep
 
-supported_models = [ 60062, 60121, 60181 ]
+supported_models = [ 60062, 60121, 60181, 60065 ]
 verbose_mode = 0
 
 


### PR DESCRIPTION
Tested with my brand new RD6006P, flashing with stock firmware 1.39 works.
(UniSoft's firmware flashes, however screen shows artefacts both with windows/python flasher)