### PR TITLE
Small typo. Bootloader version is 1.13, FW version is 1.38.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ RIDEN|RD6012|Tested with Bootloader V1.09
 RIDEN|RD6012P|Tested with Bootloader V1.14
 RIDEN|RD6018|Tested with Bootloader V1.10
 RIDEN|RD6018W|Tested with Bootloader V1.12
-RIDEN|RD6024|Tested with Bootloader v1.38
+RIDEN|RD6024|Tested with Bootloader v1.13
 
 ## Updating Firmware
 


### PR DESCRIPTION
Just a small detail. The test I did with the RD6024 in issue #10 was performed using

> RD6024 Bootloader V1.13
> Firmware Version:V1.38

So, correcting the version number shown in the README.